### PR TITLE
changed post type to 'kind'

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,0 +1,3 @@
+class Post < ActiveRecord::Base
+  # Remember to create a migration!
+end

--- a/db/migrate/20160218112307_create_posts.rb
+++ b/db/migrate/20160218112307_create_posts.rb
@@ -2,7 +2,7 @@ class CreatePosts < ActiveRecord::Migration
   def change
     create_table :posts do |t|
       t.text    :title
-      t.string  :type
+      t.string  :kind
       t.integer :user_id
       t.integer :post_id
       t.timestamps

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -11,6 +11,12 @@ users = 10.times.map do
 end
 
 Post.delete_all
-  Post.create!(:user_id =>)
+#10 random questions
+posts= 10.times.map do
+  Post.create!(:user_id => 1+ Random.rand(10),
+               :kind =>     "question",
+               :title =>  Faker::Lorem.sentence + "?")
+end
+
 
 #create

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,3 +9,8 @@ users = 10.times.map do
                 :email      => Faker::Internet.email,
                 :password   => 'password' )
 end
+
+Post.delete_all
+  Post.create!(:user_id =>)
+
+#create


### PR DESCRIPTION
as @timurcatakli pointed out, "type" is a reserved word and will cause problems for us. 

If you've already migrated, drop the tables and recreate- I'm sorry to change a past migration but I don't want a reserved word anywhere near our solution, so I didn't do a migration to change field name. 
